### PR TITLE
"Use" statements in example

### DIFF
--- a/general-configuration.md
+++ b/general-configuration.md
@@ -66,15 +66,14 @@ The `resolveId()` method should return the **ID** of the currently logged `User`
 <?php
 namespace App;
 
-use Auth;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
 use OwenIt\Auditing\Contracts\Auditable;
 use OwenIt\Auditing\Contracts\UserResolver;
-use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
 
 class User extends Model implements Auditable, UserResolver
 {
-    use AuditableContract;
+    use \OwenIt\Auditing\Contracts\Auditable;
 
     /**
      * {@inheritdoc}

--- a/general-configuration.md
+++ b/general-configuration.md
@@ -66,13 +66,15 @@ The `resolveId()` method should return the **ID** of the currently logged `User`
 <?php
 namespace App;
 
+use Auth;
 use Illuminate\Database\Eloquent\Model;
 use OwenIt\Auditing\Contracts\Auditable;
 use OwenIt\Auditing\Contracts\UserResolver;
+use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
 
 class User extends Model implements Auditable, UserResolver
 {
-    use \OwenIt\Auditing\Auditable;
+    use AuditableContract;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Added missing "use Auth;" in an example, and also added a use alias statement for the auditable contract.