### PR TITLE
"Use" statements in example (#47)

### DIFF
--- a/general-configuration.md
+++ b/general-configuration.md
@@ -67,12 +67,13 @@ The `resolveId()` method should return the **ID** of the currently logged `User`
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
 use OwenIt\Auditing\Contracts\Auditable;
 use OwenIt\Auditing\Contracts\UserResolver;
 
 class User extends Model implements Auditable, UserResolver
 {
-    use \OwenIt\Auditing\Auditable;
+    use \OwenIt\Auditing\Contracts\Auditable;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
* "Use" statements in example

Added missing "use Auth;" in an example, and also added a use alias statement for the auditable contract.

* Update general-configuration.md