### PR TITLE
Globally Disable Auditing

### DIFF
--- a/general-configuration.md
+++ b/general-configuration.md
@@ -16,6 +16,19 @@ return [
 ];
 ```
 
+## Audit disabled
+By default, the package will audit everything.
+
+```php
+return [
+    // ...
+
+    'disabled' => false,
+
+    // ...
+];
+```
+
 Read more about it in the [Audit Implementation](audit-implementation) section.
 
 ## User


### PR DESCRIPTION
There are cases where we don't want to audit while testing, running database seeding, etc... There needs to be a way to turn auditing off and on from configuration.