### PR TITLE
Adds information on using the AuditableObserver

### DIFF
--- a/model-setup.md
+++ b/model-setup.md
@@ -20,3 +20,15 @@ class User extends Model implements Auditable
 
 By default, the `Database` audit driver will be used.
 If needed, you can also implement your own [Audit Driver](audit-drivers).
+
+# Setting up the Model Observer
+
+The last step in setting your model up for is adding its observer to one of your service providers.
+
+For a model like your `User` model above, you would add:
+
+```
+\App\User::observe(\OwenIt\Auditing\AuditableObserver::class);
+```
+
+to any of the service provider classes' `boot` method [as explained in the Laravel documentation for observers](https://laravel.com/docs/5.5/eloquent#observers).


### PR DESCRIPTION
This commit adds some missing information on adding the `AuditableObserver` to your application to make auditing work. Without telling the app about the `AuditableObserver` the Eloquent events will come and go without any audits being created.