### PR TITLE
Fixed typos/errors in auditor in mongo

### DIFF
--- a/audit-implementation.md
+++ b/audit-implementation.md
@@ -17,7 +17,7 @@ Implementation:
 namespace App\Models;
 
 use Jenssegers\Mongodb\Eloquent\Model;
-use Jenssegers\Mongodb\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class MongoAudit extends Model implements \OwenIt\Auditing\Contracts\Audit
 {
@@ -36,6 +36,14 @@ class MongoAudit extends Model implements \OwenIt\Auditing\Contracts\Audit
         'new_values'   => 'json',
         'auditable_id' => 'integer',
     ];
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getTable(): string
+    {
+        return parent::getTable();
+    }
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Hi there,

My implementation is using mongo. I've tried new version (8.0.3), the example doesn't work in php 7.1.9. 

So wrong items:
1. \OwenIt\Auditing\Contracts\Audit contract require method getTable return string
2.  According to the same contract, MorphTo must be Illuminate\Database\Eloquent\Relations\MorphTo

Please correct me if I wrong