### PR TITLE
Correction of a bug in the documentation

### DIFF
--- a/audit-transformation.md
+++ b/audit-transformation.md
@@ -22,8 +22,11 @@ class User extends Model implements Auditable
      */
     public function transformAudit(array $data): array
     {
-        if (Arr::has($data, 'new_values.role_id')) {
+        if (Arr::has($data, 'old_values.role_id')) {
             $data['old_values']['role_name'] = Role::find($this->getOriginal('role_id'))->name;
+        }
+    
+        if (Arr::has($data, 'new_values.role_id')) {
             $data['new_values']['role_name'] = Role::find($this->getAttribute('role_id'))->name;
         }
 


### PR DESCRIPTION
This case must be considered as two separate conditions. It is not possible to check if the value is present only in the "new values" array, because during the record 'created' event, "role_id" will not appear in the "old values" array yet, so we will get ErrorException "Trying to get property 'role_id' of non-object ". I think that it would also be worth considering one place where we could define what values from the array in each instance should be converted into what values provided by us. :)