### PR TITLE
Changes to reflect a mongo configuration

### DIFF
--- a/audit-implementation.md
+++ b/audit-implementation.md
@@ -33,7 +33,6 @@ class MongoAudit extends Model implements \OwenIt\Auditing\Contracts\Audit
     protected $casts = [
         'old_values'   => 'json',
         'new_values'   => 'json',
-        'auditable_id' => 'integer',
     ];
 
     /**
@@ -68,6 +67,14 @@ return [
 
     'implementation' => App\Models\MongoAudit::class,
 
+    // Uncomment below if you need to specify the details of the mongo database connection (useful in hybrid setups with multiple DBs)
+    // 'drivers' => [
+    //     'database' => [
+    //         'table' => 'audits',
+    //         'connection' => 'mongodb'
+    //     ]
+    // ],    
+    
     // ...
 ];
 ```


### PR DESCRIPTION
1. Mongo records likely shouldn't have the ID field cast to integer since mongo doesn't use integers for IDs. (I guess this depends on if the auditable model is stored in mongo, which I imagine it usually is if using mongo to store audits).

2. Added some comments about configuring the mongo connection details for audits (something I was unable to find in the docs and had to dig through source to figure out).